### PR TITLE
Update dockerfile

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -13,7 +13,7 @@ RUN echo "Checking contents of /usr/src/ssh_rss/build/install:" && \
     ls -R /usr/src/ssh_rss/build/install
 
 #Second stage:
-FROM openjdk:17-jdk-slim as stage-1
+FROM openjdk:21-jdk-slim as stage-1
 # Start with a new base image - from the registry
 WORKDIR /root/
 COPY --from=stage-0 /usr/src/ssh_rss/build/install/PRP-Recipe-Suggestion-Solution .


### PR DESCRIPTION
updated the java version as I was getting the error:

2024-12-10 13:13:45 Error: LinkageError occurred while loading main class org.example.App
2024-12-10 13:13:45     java.lang.UnsupportedClassVersionError: org/example/App has been compiled by a more recent version of the Java Runtime (class file version 67.0), this version of the Java Runtime only recognizes class file versions up to 61.0